### PR TITLE
Fix error when empty line found in os-release file, see #40.

### DIFF
--- a/internal/collector/linux_sysinfo.go
+++ b/internal/collector/linux_sysinfo.go
@@ -114,6 +114,11 @@ func parseOsRelease(r io.Reader) (string, string, error) {
 	var name, version string
 
 	for scanner.Scan() {
+		// Skip empty lines
+		if scanner.Text() == "" {
+			continue
+		}
+
 		parts := strings.SplitN(scanner.Text(), "=", 2)
 
 		if len(parts) != 2 {

--- a/internal/collector/testdata/etc/os-release.golden
+++ b/internal/collector/testdata/etc/os-release.golden
@@ -2,6 +2,7 @@ NAME="Ubuntu"
 VERSION="20.04.2 LTS (Focal Fossa)"
 ID=ubuntu
 ID_LIKE=debian
+
 PRETTY_NAME="Ubuntu 20.04.2 LTS"
 VERSION_ID="20.04"
 HOME_URL="https://www.ubuntu.com/"


### PR DESCRIPTION
When empty line found in os-release file, pgscv fails and skip further reading.